### PR TITLE
Add AGENTS.md with branch backup rule for merges into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Before merging any branch into `main`, create a backup branch from the branch being merged.
+- Name the backup branch `<branch_to_be_merged>_backup`.
+
+- This rule applies to all future merges into `main`.


### PR DESCRIPTION
### Motivation
- Introduce a simple repository policy to ensure backups are created before merging branches into `main`.

### Description
- Add `AGENTS.md` containing the instruction to create a backup branch named `<branch_to_be_merged>_backup` before merging any branch into `main`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04dc2e992483269d88c992f7a2748f)