### PR TITLE
Rewrite README to document /tariff and /octopus endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,48 @@
-[![example-flask](https://github.com/koyeb/example-flask/actions/workflows/deploy.yaml/badge.svg)](https://github.com/koyeb/example-flask/actions)
+# Avon Flask API
 
-<div align="center">
-  <a href="https://koyeb.com">
-    <img src="https://www.koyeb.com/static/images/icons/koyeb.svg" alt="Logo" width="80" height="80">
-  </a>
-  <h3 align="center">Koyeb Serverless Platform</h3>
-  <p align="center">
-    Deploy a Flask application on Koyeb
-    <br />
-    <a href="https://koyeb.com">Learn more about Koyeb</a>
-    ·
-    <a href="https://koyeb.com/docs">Explore the documentation</a>
-    ·
-    <a href="https://koyeb.com/tutorials">Discover our tutorials</a>
-  </p>
-</div>
+A small Flask app focused on Octopus Agile tariff planning.
 
+## Endpoints
 
-## About Koyeb and the Flask example application
+### `GET /tariff`
+Returns the cheapest start time for a device run based on the requested duration.
 
-Koyeb is a developer-friendly serverless platform to deploy apps globally. No-ops, servers, or infrastructure management.
-This repository contains a Flask application you can deploy on the Koyeb serverless platform for testing.
+**Query parameters**
+- `numHours` (required, number): how long the appliance will run.
 
-This example application is designed to show how a Flask application can be deployed on Koyeb.
+**Success response**
+- `200 OK`
+```json
+{
+  "startTime": "2026-05-13 17:00:00"
+}
+```
 
-## Getting Started
+**Error responses**
+- `400 Bad Request` when `numHours` is missing or not numeric.
+- `502 Bad Gateway` when upstream tariff data cannot be fetched.
 
-Follow the steps below to deploy and run the Flask application on your Koyeb account.
+### `GET /octopus`
+Renders an HTML page showing best tariff windows for preset durations (`1` to `3.5` hours).
 
-### Requirements
+- Uses live Octopus tariff data.
+- Displays start/end times, total tariff, and average tariff.
+- Highlights cases where the total tariff is negative (credit periods).
 
-You need a Koyeb account to successfully deploy and run this application. If you don't already have an account, you can sign-up for free [here](https://app.koyeb.com/auth/signup).
+## Local run
 
-### Deploy using the Koyeb button
+```bash
+python app.py
+```
 
-The fastest way to deploy the Flask application is to click the **Deploy to Koyeb** button below.
+Default Flask URL:
+- `http://127.0.0.1:5000/tariff?numHours=2`
+- `http://127.0.0.1:5000/octopus`
 
-[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=git&repository=github.com/koyeb/example-flask&branch=main&name=flask-on-koyeb)
+## Environment variable
 
-Clicking on this button brings you to the Koyeb App creation page with everything pre-set to launch this application.
+Set the Octopus API key before running:
 
-_To modify this application example, you will need to fork this repository. Checkout the [fork and deploy](#fork-and-deploy-to-koyeb) instructions._
-
-### Fork and deploy to Koyeb
-
-If you want to customize and enhance this application, you need to fork this repository.
-
-If you used the **Deploy to Koyeb** button, you can simply link your service to your forked repository to be able to push changes.
-Alternatively, you can manually create the application as described below.
-
-On the [Koyeb Control Panel](https://app.koyeb.com/), on the **Overview** tab, click the **Create Web Service** button to begin.
-
-1. Select **GitHub** as the deployment method.
-2. In the repositories list, select the repository you just forked.
-3. In the **Builder** section, click the **override** toggle associated with the **Run command** and enter `gunicorn app:app` in the field.
-4. Choose a name for your App and Service, i.e `flask-on-koyeb`, and click **Deploy**.
-
-You land on the deployment page where you can follow the build of your Flask application. Once the build is completed, your application is being deployed and you will be able to access it via `<YOUR_APP_NAME>-<YOUR_ORG_NAME>.koyeb.app`.
-
-## Contributing
-
-If you have any questions, ideas or suggestions regarding this application sample, feel free to open an [issue](//github.com//koyeb/example-flask/issues) or fork this repository and open a [pull request](//github.com/koyeb/example-flask/pulls).
-
-## Contact
-
-[Koyeb](https://www.koyeb.com) - [@gokoyeb](https://twitter.com/gokoyeb) - [Slack](http://slack.koyeb.com/)
+```bash
+export OCTOPUS_KEY="your_octopus_api_key"
+```


### PR DESCRIPTION
### Motivation
- Replace the generic template README with focused project documentation that reflects this repository's actual purpose: Octopus Agile tariff planning via the `/tariff` and `/octopus` endpoints.

### Description
- Rewrote `README.md` to remove Koyeb/template content and add concise usage for `GET /tariff` (query param `numHours`, success and error responses) and `GET /octopus` (HTML view of best tariff windows), plus local run instructions (`python app.py`) and the required `OCTOPUS_KEY` environment variable.

### Testing
- Documentation-only change; no automated tests were executed because this update only modifies `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e78dc408832682f02c30bb72b77d)