### PR TITLE
Show half-hour tariff slot details for Octopus endpoint and include slots in window results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@
 
 - This rule applies to all future merges into `main`.
 
+## Octopus Endpoint Notes
+
+- The `/octopus` endpoint returns an HTML page (not JSON).
+- It shows the best (cheapest) continuous upcoming usage window for each supported appliance duration.
+- For each suggested window, the UI includes a collapsed-by-default expandable section with a mini table of half-hour slots and their tariff values in `p/kWh`.
+
 ## Study Question Storage
 
 - Store multiple choice study questions under `static/<Subject>/<Category>/questions.json`.

--- a/app.py
+++ b/app.py
@@ -117,6 +117,14 @@ def octopus():
         row['total_tariff_label'] = f"{row['total_tariff']:.2f} p/kWh"
         row['average_tariff_label'] = f"{row['average_tariff']:.2f} p/kWh"
         row['is_credit'] = row['total_tariff'] < 0
+        row['slot_details'] = [
+            {
+                'start_label': slot['start_time'].strftime('%d %b %Y, %H:%M'),
+                'end_label': slot['end_time'].strftime('%d %b %Y, %H:%M'),
+                'tariff_label': f"{slot['tariff']:.2f} p/kWh",
+            }
+            for slot in row.get('slots', [])
+        ]
 
     return render_template(
         'octopus.html',

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -218,6 +218,47 @@ footer {
     color: #8a1c1c;
 }
 
+.octopus-slot-details {
+    grid-column: 1 / -1;
+}
+
+.octopus-slot-details details {
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.9);
+}
+
+.octopus-slot-details summary {
+    cursor: pointer;
+    padding: 0.65rem 0.8rem;
+    font-weight: 700;
+    color: #334155;
+}
+
+.octopus-slot-table-wrap {
+    padding: 0 0.8rem 0.8rem;
+}
+
+.octopus-slot-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+.octopus-slot-table th,
+.octopus-slot-table td {
+    text-align: left;
+    padding: 0.45rem 0.3rem;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.octopus-slot-table th {
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #52606d;
+}
+
 @media (max-width: 900px) {
     .octopus-table-header {
         flex-direction: column;

--- a/tariff_utils.py
+++ b/tariff_utils.py
@@ -84,6 +84,14 @@ def find_best_tariff_window(duration_hours, api_key, available_slots=None):
                 "end_time": consecutive_slots[-1]["valid_to"],
                 "total_tariff": total_tariff,
                 "average_tariff": total_tariff / required_slots,
+                "slots": [
+                    {
+                        "start_time": slot["valid_from"],
+                        "end_time": slot["valid_to"],
+                        "tariff": slot["tariff"],
+                    }
+                    for slot in consecutive_slots
+                ],
             }
             print(
                 "BEST TIMESLOT FOUND at "

--- a/templates/octopus.html
+++ b/templates/octopus.html
@@ -73,6 +73,31 @@
                     <div class="octopus-cell" role="cell" data-label="Average slot tariff">
                         {{ row.average_tariff_label }}
                     </div>
+                    <div class="octopus-slot-details" role="cell">
+                        <details>
+                            <summary>Half-hour tariff slots in this window</summary>
+                            <div class="octopus-slot-table-wrap">
+                                <table class="octopus-slot-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Start</th>
+                                            <th>End</th>
+                                            <th>Tariff</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for slot in row.slot_details %}
+                                        <tr>
+                                            <td>{{ slot.start_label }}</td>
+                                            <td>{{ slot.end_label }}</td>
+                                            <td>{{ slot.tariff_label }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </details>
+                    </div>
                     {% endif %}
                 </article>
                 {% endfor %}


### PR DESCRIPTION
### Motivation

- Provide users with a detailed, expandable view of the individual half-hour tariff slots that make up each suggested continuous window returned by the `/octopus` endpoint.
- Ensure the tariff computation code returns the constituent slots so the template can render a mini table of slot start/end times and per-slot tariffs.
- Document the endpoint behavior in `AGENTS.md` so future edits and agents know the endpoint returns HTML and includes slot-detail UI.

### Description

- Updated `tariff_utils.find_best_tariff_window` to include a `slots` list with each slot's `start_time`, `end_time`, and `tariff` in the returned best-window object.
- Updated `app.octopus` to compute `slot_details` labels from the returned `slots` and pass them to the template, and set an `is_credit` flag for display.
- Extended the `templates/octopus.html` template to render a collapsed `details` section containing a mini table of `Start`, `End`, and `Tariff` per half-hour slot for each window.
- Added CSS rules in `static/css/styles.css` to style the slot details block, `details/summary`, and the slot table.
- Added brief documentation in `AGENTS.md` under `Octopus Endpoint Notes` describing that `/octopus` returns HTML, shows the cheapest continuous windows, and includes an expandable mini table of half-hour slots with tariffs.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084bdaabc48326a57daadfa0a28b9f)