### PR TITLE
Replace multi-select with details/checkbox picker for vocab types and update styles/JS

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -409,8 +409,10 @@ footer {
 }
 
 .vocab-type-control {
-    display: grid;
-    gap: 0.3rem;
+    min-width: 220px;
+    border: 0;
+    padding: 0;
+    margin: 0;
     color: #5a6475;
     font-size: 0.72rem;
     font-weight: 700;
@@ -418,17 +420,41 @@ footer {
     text-transform: uppercase;
 }
 
-.vocab-type-select {
-    min-width: 210px;
-    min-height: 2.5rem;
-    padding: 0.35rem;
+.vocab-type-control legend {
+    padding: 0;
+    margin-bottom: 0.3rem;
+}
+
+.vocab-type-picker {
     border: 1px solid #c6d1de;
     border-radius: 7px;
-    font: inherit;
+    background: #fff;
+}
+
+.vocab-type-picker summary {
+    cursor: pointer;
+    padding: 0.5rem 0.6rem;
     color: #172033;
     text-transform: none;
     letter-spacing: 0;
-    background: #fff;
+    font-size: 0.9rem;
+}
+
+.vocab-type-options {
+    display: grid;
+    gap: 0.4rem;
+    padding: 0.2rem 0.6rem 0.6rem;
+}
+
+.vocab-type-option {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: #172033;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.85rem;
+    font-weight: 500;
 }
 
 

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -21,9 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const scoreElement = document.getElementById('vocab-score');
     const submitStatus = document.getElementById('vocab-submit-status');
     const submitButton = document.getElementById('vocab-submit');
-    const typeSelect = document.getElementById('vocab-types');
+    const typeContainer = document.getElementById('vocab-types');
+    const typeSummary = document.getElementById('vocab-type-summary');
 
-    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeSelect) {
+    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary) {
         return;
     }
 
@@ -33,12 +34,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const getSelectedCount = () => allowedCounts[Number(countInput.value)] || 10;
 
-    const getSelectedTypes = () => Array.from(typeSelect.selectedOptions).map((option) => option.value);
+    const getTypeInputs = () => Array.from(typeContainer.querySelectorAll('input[type="checkbox"]'));
+
+    const getSelectedTypes = () => getTypeInputs().filter((input) => input.checked).map((input) => input.value);
 
     const selectAllTypes = () => {
-        Array.from(typeSelect.options).forEach((option) => {
-            option.selected = true;
+        getTypeInputs().forEach((input) => {
+            input.checked = true;
         });
+        updateTypeSummary();
+    };
+
+    const updateTypeSummary = () => {
+        const selectedTypes = getSelectedTypes();
+
+        if (!selectedTypes.length) {
+            typeSummary.textContent = 'No type selected';
+            return;
+        }
+
+        if (selectedTypes.length === allowedTypes.length) {
+            typeSummary.textContent = 'All types selected';
+            return;
+        }
+
+        typeSummary.textContent = `${selectedTypes.length} types selected`;
     };
 
     // Submit feedback and score use separate labels so either can update alone.
@@ -200,6 +220,14 @@ document.addEventListener('DOMContentLoaded', () => {
     countInput.addEventListener('input', () => {
         countLabel.textContent = String(getSelectedCount());
     });
+
+    typeContainer.addEventListener('change', (event) => {
+        if (event.target.matches('input[type="checkbox"]')) {
+            updateTypeSummary();
+        }
+    });
+
+    updateTypeSummary();
 
     regenerateButton.addEventListener('click', async () => {
         const count = getSelectedCount();

--- a/templates/vocab.html
+++ b/templates/vocab.html
@@ -36,13 +36,20 @@
                     value="{{ allowed_counts.index(selected_count) }}"
                     aria-label="Number of questions"
                 >
-                <label class="vocab-type-control" for="vocab-types">Question types
-                    <select id="vocab-types" class="vocab-type-select" multiple aria-label="Question types for regeneration">
-                        {% for question_type in allowed_types %}
-                        <option value="{{ question_type }}" selected>{{ question_type.replace("_", " ").title() }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
+                <fieldset class="vocab-type-control" aria-label="Question types for regeneration">
+                    <legend>Question types</legend>
+                    <details class="vocab-type-picker" id="vocab-type-picker">
+                        <summary id="vocab-type-summary">All types selected</summary>
+                        <div class="vocab-type-options" id="vocab-types">
+                            {% for question_type in allowed_types %}
+                            <label class="vocab-type-option">
+                                <input type="checkbox" value="{{ question_type }}" checked>
+                                <span>{{ question_type.replace("_", " ").title() }}</span>
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </details>
+                </fieldset>
                 <button type="button" class="vocab-button vocab-button-secondary" id="vocab-regenerate">Regenerate</button>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Improve the question type picker UI by replacing a native multi-select with a clearer, mobile-friendly details/checkbox picker and visible summary. 
- Simplify interactions so regeneration works without a full page reload and give clearer feedback about selected types. 
- Update styles to match the new markup and preserve accessible labels and keyboard interaction.

### Description
- Replace the `<select multiple id="vocab-types">` in `templates/vocab.html` with a `fieldset` containing a `details`-based picker and a list of checkbox inputs inside the element with id `vocab-types` and a summary element `vocab-type-summary` for status text. 
- Update `static/js/scripts.js` to stop using `selectedOptions` and instead gather checkbox inputs via `querySelectorAll('input[type="checkbox"]')`, add `updateTypeSummary()` to show selection count/state, add a change listener on the container to update the summary, and maintain `selectAllTypes()` behavior when no types are checked. 
- Replace and add CSS rules in `static/css/styles.css` to style the new picker: add rules for `.vocab-type-picker`, `.vocab-type-options`, `.vocab-type-option`, and `legend`/`summary` adjustments, and remove the old `.vocab-type-select` grid settings. 
- Ensure regeneration encodes the selected types into the `/vocab/questions?types=` query string and that the controls are present-checked on DOM ready.

### Testing
- Ran the project's automated test suite including backend unit tests and frontend script checks, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d570b1b083269b97a70bb655b043)