### PR TITLE
Add nine new entries to vocabulary word bank

### DIFF
--- a/static/English/Vocabulary/word_bank.txt
+++ b/static/English/Vocabulary/word_bank.txt
@@ -323,3 +323,12 @@ alternative
 hypothesis
 analyze
 summarize
+billeting
+imminent
+Bewildered
+Adamant
+Stockily
+Threadbare
+Gruffly
+Mackintosh
+Plimsoll


### PR DESCRIPTION
### Motivation
- Add the user-provided vocabulary items to the project's word bank so they are available for question authoring and to follow the local `word_bank.txt` maintenance rules (one item per line, no duplicates). 

### Description
- Appended nine words to `static/English/Vocabulary/word_bank.txt`: `billeting`, `imminent`, `Bewildered`, `Adamant`, `Stockily`, `Threadbare`, `Gruffly`, `Mackintosh`, and `Plimsoll`, after confirming none were already present (case-insensitive). 

### Testing
- Verified absence of duplicates with a short Python check (`python3 - <<'PY' ... PY`), confirmed the new lines appear at the end of `static/English/Vocabulary/word_bank.txt`, ran `git status --short`, and committed the change with message `Add new vocabulary words to word bank`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3c240234832684e521cbf6d98590)