### PR TITLE
Add DB-backed adaptive vocabulary profiles, weighted sampling, and frontend profile selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,10 @@ import os
 import json
 from datetime import datetime, timedelta
 import random
+from collections import defaultdict
+from decimal import Decimal
+import psycopg2
+from psycopg2.extras import RealDictCursor
 
 api_key = os.getenv("OCTOPUS_KEY")
 
@@ -29,6 +33,7 @@ VOCAB_ALLOWED_TYPES = [
 ]
 VOCAB_RECENT_QUESTION_SESSION_KEY = 'recent_vocab_question_ids'
 VOCAB_RECENT_QUESTION_LIMIT = 40
+VOCAB_PROFILE_SESSION_KEY = 'active_vocab_profile_key'
 
 
 @app.route('/')
@@ -142,6 +147,160 @@ def octopus():
     )
 
 
+def _get_db_connection():
+    database_url = os.getenv('DATABASE_URL')
+    if not database_url:
+        raise RuntimeError('DATABASE_URL is not configured.')
+    return psycopg2.connect(database_url)
+
+
+def _fetch_vocab_profiles():
+    with _get_db_connection() as connection:
+        with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(
+                """
+                SELECT profile_key, display_name, is_guest, is_default
+                FROM vocab_profiles
+                ORDER BY is_default DESC, id ASC
+                """
+            )
+            profiles = cursor.fetchall()
+
+    if not profiles:
+        raise RuntimeError('No vocabulary profiles are configured.')
+
+    return [dict(row) for row in profiles]
+
+
+def _resolve_active_profile(profiles):
+    requested_profile = request.args.get('profile', type=str)
+    if requested_profile:
+        requested_profile = requested_profile.strip().lower()
+
+    available = {profile['profile_key']: profile for profile in profiles}
+
+    session_profile_key = session.get(VOCAB_PROFILE_SESSION_KEY)
+
+    if requested_profile and requested_profile in available:
+        active_profile_key = requested_profile
+    elif session_profile_key in available:
+        active_profile_key = session_profile_key
+    else:
+        default_profile = next((profile for profile in profiles if profile.get('is_default')), profiles[0])
+        active_profile_key = default_profile['profile_key']
+
+    session[VOCAB_PROFILE_SESSION_KEY] = active_profile_key
+    return available[active_profile_key], [profile['profile_key'] for profile in profiles]
+
+
+def _load_word_weights(profile):
+    if profile.get('is_guest'):
+        return {}
+
+    with _get_db_connection() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT target_word, weight
+                FROM vocab_word_state
+                WHERE profile_id = (SELECT id FROM vocab_profiles WHERE profile_key = %s)
+                """,
+                (profile['profile_key'],),
+            )
+            rows = cursor.fetchall()
+
+    return {target_word: float(weight) for target_word, weight in rows}
+
+
+def _weighted_sample_without_replacement(questions, weights, sample_size):
+    if sample_size <= 0:
+        return []
+
+    keyed_questions = []
+    for question in questions:
+        target_word = question.get('target_word', '')
+        weight = max(0.01, weights.get(target_word, 1.0))
+        u = random.random() or 1e-9
+        key = u ** (1.0 / weight)
+        keyed_questions.append((key, question))
+
+    keyed_questions.sort(key=lambda item: item[0], reverse=True)
+    return [item[1] for item in keyed_questions[:sample_size]]
+
+
+def _apply_weight_transition(weight, consecutive_correct, was_correct):
+    if not was_correct:
+        if weight in (0.5, 1.0):
+            return 2.0, 0
+        if weight == 2.0:
+            return 4.0, 0
+        return 4.0, 0
+
+    next_cc = consecutive_correct + 1
+    if weight == 4.0 and next_cc >= 2:
+        return 2.0, 0
+    if weight == 2.0 and next_cc >= 2:
+        return 1.0, 0
+    if weight == 1.0 and next_cc >= 3:
+        return 0.5, 0
+    return weight, next_cc
+
+
+def _record_vocab_submission(profile_key, word_outcomes, quiz_id=None):
+    with _get_db_connection() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT id, is_guest FROM vocab_profiles WHERE profile_key = %s', (profile_key,))
+            profile_row = cursor.fetchone()
+            if not profile_row:
+                raise ValueError('Unknown profile.')
+
+            profile_id, is_guest = profile_row
+            if is_guest:
+                return {'updated_words': 0, 'skipped_updates': True}
+
+            updated_words = 0
+            for target_word, was_correct in word_outcomes.items():
+                cursor.execute(
+                    """
+                    SELECT weight, consecutive_correct
+                    FROM vocab_word_state
+                    WHERE profile_id = %s AND target_word = %s
+                    FOR UPDATE
+                    """,
+                    (profile_id, target_word),
+                )
+                state_row = cursor.fetchone()
+                current_weight = float(state_row[0]) if state_row else 1.0
+                current_cc = state_row[1] if state_row else 0
+
+                new_weight, new_cc = _apply_weight_transition(current_weight, current_cc, was_correct)
+
+                cursor.execute(
+                    """
+                    INSERT INTO vocab_word_state (profile_id, target_word, weight, consecutive_correct, last_answered_at, updated_at)
+                    VALUES (%s, %s, %s, %s, NOW(), NOW())
+                    ON CONFLICT (profile_id, target_word)
+                    DO UPDATE SET
+                        weight = EXCLUDED.weight,
+                        consecutive_correct = EXCLUDED.consecutive_correct,
+                        last_answered_at = EXCLUDED.last_answered_at,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    (profile_id, target_word, Decimal(str(new_weight)), new_cc),
+                )
+
+                cursor.execute(
+                    """
+                    INSERT INTO vocab_answer_events (profile_id, target_word, was_correct, submitted_at, quiz_id, created_at)
+                    VALUES (%s, %s, %s, NOW(), %s, NOW())
+                    """,
+                    (profile_id, target_word, was_correct, quiz_id),
+                )
+                updated_words += 1
+
+    return {'updated_words': updated_words, 'skipped_updates': False}
+
+
 def _get_vocab_count(default=10):
     """Return a supported quiz size, falling back to the default for bad input."""
     count = request.args.get('count', default=default, type=int)
@@ -177,7 +336,7 @@ def _load_vocab_questions():
     return questions
 
 
-def _sample_vocab_questions(count, selected_types=None):
+def _sample_vocab_questions(count, selected_types=None, profile=None):
     """Pick random questions, preferring IDs the current user has not just seen."""
     questions = _load_vocab_questions()
 
@@ -192,23 +351,15 @@ def _sample_vocab_questions(count, selected_types=None):
         if question.get('id') not in recent_question_id_set
     ]
 
-    if sample_size and len(fresh_questions) >= sample_size:
-        selected_questions = random.sample(fresh_questions, sample_size)
-    elif sample_size:
-        selected_questions = list(fresh_questions)
-        selected_question_ids = {
-            question.get('id') for question in selected_questions
-            if question.get('id')
-        }
-        refill_questions = [
-            question for question in questions
-            if question.get('id') not in selected_question_ids
-        ]
-        remaining_count = sample_size - len(selected_questions)
-        selected_questions.extend(random.sample(refill_questions, remaining_count))
-        random.shuffle(selected_questions)
-    else:
+    if not sample_size:
         selected_questions = []
+    else:
+        working_pool = fresh_questions if len(fresh_questions) >= sample_size else questions
+        if profile and not profile.get('is_guest'):
+            weights = _load_word_weights(profile)
+            selected_questions = _weighted_sample_without_replacement(working_pool, weights, sample_size)
+        else:
+            selected_questions = random.sample(working_pool, sample_size)
 
     selected_ids = [question.get('id') for question in selected_questions if question.get('id')]
     session[VOCAB_RECENT_QUESTION_SESSION_KEY] = (
@@ -234,7 +385,9 @@ def vocab():
     selected_types = _get_vocab_types()
 
     try:
-        questions = _sample_vocab_questions(count, selected_types)
+        profiles = _fetch_vocab_profiles()
+        active_profile, available_profile_keys = _resolve_active_profile(profiles)
+        questions = _sample_vocab_questions(count, selected_types, active_profile)
     except (OSError, json.JSONDecodeError, ValueError) as error:
         return render_template(
             'vocab.html',
@@ -243,6 +396,8 @@ def vocab():
             allowed_counts=VOCAB_ALLOWED_COUNTS,
             allowed_types=VOCAB_ALLOWED_TYPES,
             page_error=str(error),
+            profiles=[],
+            active_profile_key='',
         ), 500
 
     return render_template(
@@ -252,6 +407,8 @@ def vocab():
         allowed_counts=VOCAB_ALLOWED_COUNTS,
         allowed_types=VOCAB_ALLOWED_TYPES,
         page_error=None,
+        profiles=profiles,
+        active_profile_key=active_profile['profile_key'],
     )
 
 
@@ -263,26 +420,49 @@ def vocab_questions():
     selected_types = _get_vocab_types()
 
     try:
-        questions = _sample_vocab_questions(count, selected_types)
+        profiles = _fetch_vocab_profiles()
+        active_profile, available_profile_keys = _resolve_active_profile(profiles)
+        questions = _sample_vocab_questions(count, selected_types, active_profile)
     except (OSError, json.JSONDecodeError, ValueError) as error:
         return jsonify(error=str(error)), 500
 
-    return jsonify(questions=questions, count=len(questions), selected_types=selected_types)
+    return jsonify(questions=questions, count=len(questions), selected_types=selected_types, active_profile=active_profile['profile_key'])
 
 
 @app.route('/vocab/feedback', methods=['POST'])
 def vocab_feedback():
-    """Accept first-attempt misses; currently this is a dummy receiver."""
+    """Accept first-attempt outcomes and update adaptive word state."""
     data = request.get_json(silent=True) or {}
-    missed_target_words = data.get('missed_target_words', [])
+    profile_key = str(data.get('profile_key', '')).strip().lower()
+    results = data.get('results', [])
+    quiz_id = data.get('quiz_id')
 
-    if not isinstance(missed_target_words, list):
-        return jsonify(error='missed_target_words must be a list'), 400
+    if not profile_key:
+        return jsonify(error='profile_key is required'), 400
 
-    return jsonify(
-        status='received',
-        missed_count=len(missed_target_words),
-    )
+    if not isinstance(results, list):
+        return jsonify(error='results must be a list'), 400
+
+    word_buckets = defaultdict(list)
+    for row in results:
+        if not isinstance(row, dict):
+            continue
+        target_word = str(row.get('target_word', '')).strip()
+        if not target_word:
+            continue
+        was_correct = bool(row.get('first_attempt_correct'))
+        word_buckets[target_word].append(was_correct)
+
+    word_outcomes = {word: all(attempts) for word, attempts in word_buckets.items()}
+
+    try:
+        summary = _record_vocab_submission(profile_key, word_outcomes, quiz_id=quiz_id)
+    except ValueError as error:
+        return jsonify(error=str(error)), 400
+    except RuntimeError as error:
+        return jsonify(error=str(error)), 500
+
+    return jsonify(status='received', profile_key=profile_key, processed_words=len(word_outcomes), **summary)
 
 
 @app.route('/demo_status')

--- a/migrations/001_create_vocab_adaptive_tables.sql
+++ b/migrations/001_create_vocab_adaptive_tables.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS vocab_profiles (
+  id            BIGSERIAL PRIMARY KEY,
+  profile_key   TEXT NOT NULL UNIQUE,
+  display_name  TEXT NOT NULL,
+  is_guest      BOOLEAN NOT NULL DEFAULT FALSE,
+  is_default    BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vocab_profiles_single_default
+ON vocab_profiles ((is_default))
+WHERE is_default = TRUE;
+
+CREATE TABLE IF NOT EXISTS vocab_word_state (
+  id                    BIGSERIAL PRIMARY KEY,
+  profile_id            BIGINT NOT NULL REFERENCES vocab_profiles(id) ON DELETE CASCADE,
+  target_word           TEXT NOT NULL,
+  weight                NUMERIC(2,1) NOT NULL DEFAULT 1.0
+                        CHECK (weight IN (0.5, 1.0, 2.0, 4.0)),
+  consecutive_correct   INTEGER NOT NULL DEFAULT 0 CHECK (consecutive_correct >= 0),
+  last_answered_at      TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (profile_id, target_word)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vocab_word_state_profile_weight
+  ON vocab_word_state (profile_id, weight);
+
+CREATE TABLE IF NOT EXISTS vocab_answer_events (
+  id            BIGSERIAL PRIMARY KEY,
+  profile_id    BIGINT NOT NULL REFERENCES vocab_profiles(id) ON DELETE CASCADE,
+  target_word   TEXT NOT NULL,
+  was_correct   BOOLEAN NOT NULL,
+  submitted_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  quiz_id       TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vocab_answer_events_profile_word_time
+  ON vocab_answer_events (profile_id, target_word, submitted_at DESC);

--- a/migrations/002_seed_vocab_profiles.sql
+++ b/migrations/002_seed_vocab_profiles.sql
@@ -1,0 +1,11 @@
+INSERT INTO vocab_profiles (profile_key, display_name, is_guest, is_default)
+VALUES
+  ('jinny', 'Jinny', FALSE, TRUE),
+  ('dd',    'DD',    FALSE, FALSE),
+  ('guest', 'Guest', TRUE,  FALSE)
+ON CONFLICT (profile_key) DO UPDATE
+SET
+  display_name = EXCLUDED.display_name,
+  is_guest     = EXCLUDED.is_guest,
+  is_default   = EXCLUDED.is_default,
+  updated_at   = NOW();

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ Flask-RESTX
 requests==2.26.0
 pytz
 setuptools>=70
+
+psycopg2-binary==2.9.9

--- a/static/English/Vocabulary/AGENTS.md
+++ b/static/English/Vocabulary/AGENTS.md
@@ -117,3 +117,63 @@ When the user asks for "Questions Re-balance", rebalance the candidate vocabular
    - removed entries
 
 Recommended implementation: use a short Python script with `collections.Counter` and perform deterministic filtering based on exact string matches.
+
+## Database Usage for Adaptive Vocabulary (Neon/Postgres)
+
+This project now uses PostgreSQL (Neon) for adaptive vocabulary weighting and profile-based practice behavior.
+
+### Connection
+- Database connection is provided via environment variable `DATABASE_URL`.
+- `DATABASE_URL` should be the full connection string, including `sslmode=require` for Neon.
+- Do not hardcode credentials in source files.
+
+### Where DB logic is used
+- Profile loading, active profile resolution, weighted sampling state lookup, and feedback persistence are handled in `app.py`.
+- Question content still comes from `questions.json`; DB stores learner/profile state and answer history only.
+
+### Schema overview
+The following tables are expected:
+
+1. `vocab_profiles`
+   - One row per selectable profile (for example: `jinny`, `dd`, `guest`).
+   - Important fields:
+     - `profile_key` (unique profile identifier)
+     - `display_name` (UI label)
+     - `is_guest` (guest profile bypasses adaptive writes)
+     - `is_default` (single default profile)
+
+2. `vocab_word_state`
+   - One row per `(profile_id, target_word)` adaptive state.
+   - Important fields:
+     - `weight` in `{0.5, 1.0, 2.0, 4.0}`
+     - `consecutive_correct`
+     - `last_answered_at`
+   - `UNIQUE (profile_id, target_word)` ensures one state row per word per profile.
+
+3. `vocab_answer_events`
+   - Append-only event history per word outcome.
+   - Important fields:
+     - `profile_id`
+     - `target_word`
+     - `was_correct`
+     - `submitted_at`
+     - optional `quiz_id`
+
+### How to rebuild schema from SQL files
+From repository root:
+
+1. Apply base schema:
+   - `migrations/001_create_vocab_adaptive_tables.sql`
+2. Apply baseline seed profiles:
+   - `migrations/002_seed_vocab_profiles.sql`
+
+Example:
+- `psql "$DATABASE_URL" -f migrations/001_create_vocab_adaptive_tables.sql`
+- `psql "$DATABASE_URL" -f migrations/002_seed_vocab_profiles.sql`
+
+### Seed expectations
+- Seeded profiles should include:
+  - `jinny` (default)
+  - `dd`
+  - `guest`
+- Do not pre-populate `vocab_word_state` for every `target_word`; state rows are created lazily on first recorded submission.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -661,3 +661,7 @@ footer {
         display: grid;
     }
 }
+
+.vocab-profile-control { display: flex; flex-direction: column; gap: 0.35rem; }
+.vocab-profile-select { padding: 0.45rem 0.6rem; border-radius: 0.55rem; border: 1px solid #cbd5e1; background: #fff; }
+

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -23,14 +23,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const submitButton = document.getElementById('vocab-submit');
     const typeContainer = document.getElementById('vocab-types');
     const typeSummary = document.getElementById('vocab-type-summary');
+    const profileSelect = document.getElementById('vocab-profile');
 
-    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary) {
+    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary || !profileSelect) {
         return;
     }
 
     const allowedCounts = window.vocabAllowedCounts || [5, 10, 15, 20, 25, 30];
     const allowedTypes = window.vocabAllowedTypes || [];
     let questions = window.vocabInitialQuestions || [];
+    let activeProfileKey = window.vocabActiveProfileKey || profileSelect.value;
 
     const getSelectedCount = () => allowedCounts[Number(countInput.value)] || 10;
 
@@ -195,7 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // This dummy call lets the server receive first-attempt misses while the
     // browser continues showing the mark result immediately.
-    const sendFeedback = async (missedTargetWords) => {
+    const sendFeedback = async (results) => {
         setStatus('Sending feedback...', 'pending');
 
         try {
@@ -204,7 +206,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ missed_target_words: missedTargetWords }),
+                body: JSON.stringify({
+                    profile_key: activeProfileKey,
+                    results,
+                }),
             });
 
             if (!response.ok) {
@@ -244,7 +249,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
             const typeQuery = encodeURIComponent(selectedTypes.join(','));
-            const response = await fetch(`/vocab/questions?count=${count}&types=${typeQuery}`);
+            const profileQuery = encodeURIComponent(profileSelect.value);
+            const response = await fetch(`/vocab/questions?count=${count}&types=${typeQuery}&profile=${profileQuery}`);
             const data = await response.json();
 
             if (!response.ok) {
@@ -252,6 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             questions = data.questions || [];
+            activeProfileKey = data.active_profile || profileSelect.value;
             renderQuestions();
             setStatus(`Loaded ${questions.length} questions`, 'success');
         } catch (error) {
@@ -276,12 +283,16 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    profileSelect.addEventListener('change', () => {
+        activeProfileKey = profileSelect.value;
+    });
+
     quiz.addEventListener('submit', (event) => {
         event.preventDefault();
 
-        const missedTargetWords = [];
         const questionElements = questionList.querySelectorAll('.vocab-question');
         let correctCount = 0;
+        const results = [];
 
         questionElements.forEach((questionElement) => {
             const isCorrect = markQuestion(questionElement);
@@ -290,13 +301,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 correctCount += 1;
             }
 
-            if (!isCorrect && questionElement.dataset.targetWord) {
-                missedTargetWords.push(questionElement.dataset.targetWord);
+            const targetWord = questionElement.dataset.targetWord || '';
+            if (targetWord) {
+                results.push({
+                    target_word: targetWord,
+                    first_attempt_correct: isCorrect,
+                });
             }
         });
 
         setScore(correctCount, questionElements.length);
-        sendFeedback(missedTargetWords);
+        sendFeedback(results);
         submitButton.disabled = true;
     });
 

--- a/templates/vocab.html
+++ b/templates/vocab.html
@@ -11,6 +11,8 @@
         window.vocabSelectedCount = {{ selected_count | tojson }};
         window.vocabPageError = {{ page_error | tojson }};
         window.vocabAllowedTypes = {{ allowed_types | tojson }};
+        window.vocabProfiles = {{ profiles | tojson }};
+        window.vocabActiveProfileKey = {{ active_profile_key | tojson }};
     </script>
     <script src="{{ url_for('static', filename='js/scripts.js') }}" defer></script>
 </head>
@@ -22,6 +24,14 @@
                 <h1>Practice quiz</h1>
             </div>
             <div class="vocab-controls" aria-label="Quiz controls">
+                <label class="vocab-profile-control" for="vocab-profile">
+                    <span>Profile</span>
+                    <select id="vocab-profile" class="vocab-profile-select">
+                        {% for profile in profiles %}
+                        <option value="{{ profile.profile_key }}" {% if profile.profile_key == active_profile_key %}selected{% endif %}>{{ profile.display_name }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
                 <label class="vocab-count-control" for="vocab-count">
                     <span>Questions</span>
                     <strong id="vocab-count-label">{{ selected_count }}</strong>


### PR DESCRIPTION
### Motivation

- Introduce per-user vocabulary profiles and persistent word state so quizzes can adapt to learner performance. 
- Persist answer events and word weights to allow spaced/weighted sampling and analytics. 
- Expose profile selection in the UI so users can switch between guest and named adaptive profiles.

### Description

- Added PostgreSQL schema migrations to create `vocab_profiles`, `vocab_word_state`, and `vocab_answer_events` tables and seeded initial profiles in `migrations/001_create_vocab_adaptive_tables.sql` and `migrations/002_seed_vocab_profiles.sql`.
- Implemented DB helpers and adaptive logic in `app.py`, including `_get_db_connection`, `_fetch_vocab_profiles`, `_resolve_active_profile`, `_load_word_weights`, `_weighted_sample_without_replacement`, `_apply_weight_transition`, and `_record_vocab_submission` to load profiles, sample questions by weight, and persist submission events and state.
- Updated sampling logic to accept an active `profile`, load per-word weights for non-guest profiles, and preserve recent-question history in the session for freshness.
- Extended the `/vocab/questions` and `/vocab` endpoints and the `/vocab/feedback` POST handler to accept and process profile-aware quiz results and return the active profile; added session-based active profile tracking.
- Frontend changes include a profile selector and wiring in `templates/vocab.html`, JS changes in `static/js/scripts.js` to send `profile_key` and receive `active_profile`, and CSS tweaks in `static/css/styles.css` for profile UI styling.
- Added `psycopg2-binary` to `requirements.txt` for PostgreSQL connectivity.

### Testing

- No automated tests were added or modified as part of this change.
- Recommend adding unit tests for `_apply_weight_transition`, `_weighted_sample_without_replacement`, and DB interaction wrappers, and an integration test that runs the migrations and exercises the `/vocab` and `/vocab/feedback` flows against a test PostgreSQL instance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12bdf9ccb08326b98c9b90be9722cd)