### PR TITLE
docs: expand environment variable docs with FLASK_SECRET_KEY and DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,18 @@ Default Flask URL:
 - `http://127.0.0.1:5000/octopus`
 - `http://127.0.0.1:5000/vocab`
 
-## Environment variable
+## Environment variables
 
-Set the Octopus API key before running:
+Set the environment variables before running:
 
 ```bash
 export OCTOPUS_KEY="your_octopus_api_key"
+export FLASK_SECRET_KEY="replace_with_a_random_secret"
+export DATABASE_URL="postgresql://user:password@host:5432/dbname?sslmode=require"
 ```
+
+### Variable reference
+
+- `OCTOPUS_KEY` (required for tariff endpoints): Octopus API key used by `/tariff` and `/octopus`.
+- `FLASK_SECRET_KEY` (recommended): Flask session signing key. If omitted, the app falls back to `dev-secret-key`.
+- `DATABASE_URL` (required for vocabulary profile/weight features): Primary PostgreSQL connection string.


### PR DESCRIPTION
### Motivation

- Clarify and expand the environment variable documentation so users can run the app with the correct secrets and database connection.

### Description

- Rename the section to `Environment variables` and add example exports for `FLASK_SECRET_KEY` and `DATABASE_URL` alongside `OCTOPUS_KEY`.
- Add a `Variable reference` subsection describing `OCTOPUS_KEY`, `FLASK_SECRET_KEY` (with fallback to `dev-secret-key`), and `DATABASE_URL`.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c00d34ec8326911b4393d100eeeb)