### PR TITLE
Allow profile selection by user/display name and add auto-refresh + URL sync for vocab quiz

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,16 +184,29 @@ def _fetch_vocab_profiles():
 
 
 def _resolve_active_profile(profiles):
+    requested_user = request.args.get('user', type=str)
+    if requested_user:
+        requested_user = requested_user.strip().lower()
+
     requested_profile = request.args.get('profile', type=str)
     if requested_profile:
         requested_profile = requested_profile.strip().lower()
 
     available = {profile['profile_key']: profile for profile in profiles}
+    by_display_name = {
+        str(profile.get('display_name', '')).strip().lower(): profile
+        for profile in profiles
+        if profile.get('display_name')
+    }
 
     session_profile_key = session.get(VOCAB_PROFILE_SESSION_KEY)
 
     if requested_profile and requested_profile in available:
         active_profile_key = requested_profile
+    elif requested_user and requested_user in available:
+        active_profile_key = requested_user
+    elif requested_user and requested_user in by_display_name:
+        active_profile_key = by_display_name[requested_user]['profile_key']
     elif session_profile_key in available:
         active_profile_key = session_profile_key
     else:

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -24,8 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const typeContainer = document.getElementById('vocab-types');
     const typeSummary = document.getElementById('vocab-type-summary');
     const profileSelect = document.getElementById('vocab-profile');
+    const refreshStatus = document.getElementById('vocab-refresh-status');
 
-    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary || !profileSelect) {
+    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary || !profileSelect || !refreshStatus) {
         return;
     }
 
@@ -33,12 +34,29 @@ document.addEventListener('DOMContentLoaded', () => {
     const allowedTypes = window.vocabAllowedTypes || [];
     let questions = window.vocabInitialQuestions || [];
     let activeProfileKey = window.vocabActiveProfileKey || profileSelect.value;
+    let refreshCountdownHandle = null;
+    let refreshTickHandle = null;
+    let refreshSecondsLeft = 0;
 
     const getSelectedCount = () => allowedCounts[Number(countInput.value)] || 10;
 
     const getTypeInputs = () => Array.from(typeContainer.querySelectorAll('input[type="checkbox"]'));
 
     const getSelectedTypes = () => getTypeInputs().filter((input) => input.checked).map((input) => input.value);
+
+    const updateUrlQuery = () => {
+        const params = new URLSearchParams(window.location.search);
+        params.set('count', String(getSelectedCount()));
+        params.set('types', getSelectedTypes().join(','));
+        params.set('profile', profileSelect.value);
+        const selectedOption = profileSelect.options[profileSelect.selectedIndex];
+        if (selectedOption) {
+            params.set('user', selectedOption.textContent.trim());
+        }
+        const query = params.toString();
+        const nextUrl = `${window.location.pathname}${query ? `?${query}` : ''}`;
+        window.history.replaceState({}, '', nextUrl);
+    };
 
     const selectAllTypes = () => {
         getTypeInputs().forEach((input) => {
@@ -222,19 +240,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    countInput.addEventListener('input', () => {
-        countLabel.textContent = String(getSelectedCount());
-    });
-
-    typeContainer.addEventListener('change', (event) => {
-        if (event.target.matches('input[type="checkbox"]')) {
-            updateTypeSummary();
-        }
-    });
-
-    updateTypeSummary();
-
-    regenerateButton.addEventListener('click', async () => {
+    const regenerateQuestions = async () => {
         const count = getSelectedCount();
         let selectedTypes = getSelectedTypes();
 
@@ -266,6 +272,64 @@ document.addEventListener('DOMContentLoaded', () => {
         } finally {
             regenerateButton.disabled = false;
         }
+    };
+
+    const clearRefreshTimers = () => {
+        if (refreshCountdownHandle) {
+            clearTimeout(refreshCountdownHandle);
+        }
+        if (refreshTickHandle) {
+            clearInterval(refreshTickHandle);
+        }
+        refreshCountdownHandle = null;
+        refreshTickHandle = null;
+    };
+
+    const showRefreshCountdown = () => {
+        refreshStatus.textContent = `Questions will be refreshed in ${refreshSecondsLeft} seconds.`;
+    };
+
+    const scheduleAutoRefresh = () => {
+        clearRefreshTimers();
+        refreshSecondsLeft = 4;
+        showRefreshCountdown();
+
+        refreshTickHandle = setInterval(() => {
+            refreshSecondsLeft -= 1;
+            if (refreshSecondsLeft > 0) {
+                showRefreshCountdown();
+            }
+        }, 1000);
+
+        refreshCountdownHandle = setTimeout(async () => {
+            clearRefreshTimers();
+            refreshStatus.textContent = '';
+            await regenerateQuestions();
+        }, 4000);
+    };
+
+    countInput.addEventListener('input', () => {
+        countLabel.textContent = String(getSelectedCount());
+        updateUrlQuery();
+        scheduleAutoRefresh();
+    });
+
+    typeContainer.addEventListener('change', (event) => {
+        if (event.target.matches('input[type="checkbox"]')) {
+            updateTypeSummary();
+            updateUrlQuery();
+            scheduleAutoRefresh();
+        }
+    });
+
+    updateTypeSummary();
+    updateUrlQuery();
+
+    regenerateButton.addEventListener('click', async () => {
+        clearRefreshTimers();
+        refreshStatus.textContent = '';
+        await regenerateQuestions();
+        updateUrlQuery();
     });
 
     quiz.addEventListener('click', (event) => {
@@ -285,6 +349,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     profileSelect.addEventListener('change', () => {
         activeProfileKey = profileSelect.value;
+        updateUrlQuery();
+        scheduleAutoRefresh();
     });
 
     quiz.addEventListener('submit', (event) => {

--- a/templates/vocab.html
+++ b/templates/vocab.html
@@ -61,6 +61,7 @@
                     </details>
                 </fieldset>
                 <button type="button" class="vocab-button vocab-button-secondary" id="vocab-regenerate">Regenerate</button>
+                <span class="vocab-refresh-status" id="vocab-refresh-status" role="status" aria-live="polite"></span>
             </div>
         </section>
 


### PR DESCRIPTION
### Motivation

- Allow selecting a vocabulary profile via a `user` query parameter that can match either the profile key or the profile display name to improve linking and shareability.
- Improve the vocab quiz UX by syncing selected options to the URL and auto-refreshing questions shortly after the user changes count/type/profile settings.

### Description

- In `_resolve_active_profile` added handling of a `user` query parameter and matching against both `profile_key` and `display_name` (normalized to lower-case) to determine the active profile.
- Extracted question regeneration to `regenerateQuestions()` and added URL synchronization via `updateUrlQuery()` which updates `count`, `types`, `profile`, and `user` query params using the selected profile option label.
- Added an auto-refresh mechanism that schedules a regeneration 4 seconds after changes to count, types, or profile, shows a countdown in the UI, and clears timers when appropriate.
- Added a refresh status element to the `vocab.html` template and wired DOM checks to guard pages without the vocab UI.

### Testing

- Ran the project's automated Python test suite using `pytest`, and it completed successfully.
- No new automated frontend tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d5aba0c08326984e7344ff72c844)