### PR TITLE
Vocabulary: add reset-to-defaults button, expose defaults to JS, and allow 1-question quizzes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Renders an HTML page showing best tariff windows for preset durations (`1` to `3
 Renders an HTML vocabulary practice quiz using `static/English/Vocabulary/questions.json`.
 
 - Shows 10 random questions by default.
-- Supports quiz sizes of `5`, `10`, `15`, `20`, `25`, and `30`.
+- Supports quiz sizes of `1`, `5`, `10`, `15`, `20`, `25`, and `30`.
 - Shuffles the selected questions and each question's answer choices.
 - Marks answers in the browser when `Submit` is clicked.
 - Counts unanswered questions as wrong.
@@ -55,7 +55,7 @@ http://127.0.0.1:5000/vocab?count=15
 Returns a fresh random vocabulary question set as JSON for the page's regenerate control.
 
 **Query parameters**
-- `count` (optional, number): requested quiz size. Allowed values are `5`, `10`, `15`, `20`, `25`, and `30`.
+- `count` (optional, number): requested quiz size. Allowed values are `1`, `5`, `10`, `15`, `20`, `25`, and `30`.
 
 ### `POST /vocab/feedback`
 Dummy endpoint that accepts the vocabulary words missed on the first submit attempt.

--- a/app.py
+++ b/app.py
@@ -23,7 +23,8 @@ VOCAB_QUESTION_PATH = os.path.join(
     'Vocabulary',
     'questions.json',
 )
-VOCAB_ALLOWED_COUNTS = [5, 10, 15, 20, 25, 30]
+VOCAB_DEFAULT_COUNT = 10
+VOCAB_ALLOWED_COUNTS = [1, 5, 10, 15, 20, 25, 30]
 VOCAB_ALLOWED_TYPES = [
     'word_meaning',
     'reverse_meaning',
@@ -325,7 +326,7 @@ def _record_vocab_submission(profile_key, word_outcomes, quiz_id=None):
     return {'updated_words': updated_words, 'skipped_updates': False}
 
 
-def _get_vocab_count(default=10):
+def _get_vocab_count(default=VOCAB_DEFAULT_COUNT):
     """Return a supported quiz size, falling back to the default for bad input."""
     count = request.args.get('count', default=default, type=int)
     if count not in VOCAB_ALLOWED_COUNTS:
@@ -418,21 +419,30 @@ def vocab():
             questions=[],
             selected_count=count,
             allowed_counts=VOCAB_ALLOWED_COUNTS,
+            default_count=VOCAB_DEFAULT_COUNT,
             allowed_types=VOCAB_ALLOWED_TYPES,
             page_error=str(error),
             profiles=[],
             active_profile_key='',
+            default_profile_key='',
         ), 500
+
+    default_profile_key = next(
+        (profile['profile_key'] for profile in profiles if profile.get('is_default')),
+        profiles[0]['profile_key'],
+    )
 
     return render_template(
         'vocab.html',
         questions=questions,
         selected_count=count,
         allowed_counts=VOCAB_ALLOWED_COUNTS,
+        default_count=VOCAB_DEFAULT_COUNT,
         allowed_types=VOCAB_ALLOWED_TYPES,
         page_error=None,
         profiles=profiles,
         active_profile_key=active_profile['profile_key'],
+        default_profile_key=default_profile_key,
     )
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -403,6 +403,14 @@ footer {
     background: #245957;
 }
 
+.vocab-button-tertiary {
+    background: #5a6475;
+}
+
+.vocab-button-tertiary:hover {
+    background: #454d5c;
+}
+
 .vocab-button-small {
     min-height: 2.15rem;
     padding: 0.4rem 0.75rem;

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const countInput = document.getElementById('vocab-count');
     const countLabel = document.getElementById('vocab-count-label');
     const regenerateButton = document.getElementById('vocab-regenerate');
+    const resetDefaultsButton = document.getElementById('vocab-reset-defaults');
     const scoreElement = document.getElementById('vocab-score');
     const submitStatus = document.getElementById('vocab-submit-status');
     const submitButton = document.getElementById('vocab-submit');
@@ -26,12 +27,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const profileSelect = document.getElementById('vocab-profile');
     const refreshStatus = document.getElementById('vocab-refresh-status');
 
-    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary || !profileSelect || !refreshStatus) {
+    if (!quiz || !questionList || !countInput || !countLabel || !regenerateButton || !resetDefaultsButton || !scoreElement || !submitStatus || !submitButton || !typeContainer || !typeSummary || !profileSelect || !refreshStatus) {
         return;
     }
 
-    const allowedCounts = window.vocabAllowedCounts || [5, 10, 15, 20, 25, 30];
+    const allowedCounts = window.vocabAllowedCounts || [1, 5, 10, 15, 20, 25, 30];
     const allowedTypes = window.vocabAllowedTypes || [];
+    const defaultCount = window.vocabDefaultCount || 10;
+    const defaultProfileKey = window.vocabDefaultProfileKey || profileSelect.value;
     let questions = window.vocabInitialQuestions || [];
     let activeProfileKey = window.vocabActiveProfileKey || profileSelect.value;
     let refreshCountdownHandle = null;
@@ -56,6 +59,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const query = params.toString();
         const nextUrl = `${window.location.pathname}${query ? `?${query}` : ''}`;
         window.history.replaceState({}, '', nextUrl);
+    };
+
+    const setSelectedCount = (count) => {
+        const defaultIndex = allowedCounts.indexOf(count);
+        const fallbackIndex = allowedCounts.indexOf(10);
+        countInput.value = String(defaultIndex >= 0 ? defaultIndex : Math.max(fallbackIndex, 0));
+        countLabel.textContent = String(getSelectedCount());
     };
 
     const selectAllTypes = () => {
@@ -250,6 +260,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         regenerateButton.disabled = true;
+        resetDefaultsButton.disabled = true;
         submitButton.disabled = false;
         setStatus('Loading new questions...', 'pending');
 
@@ -271,6 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
             setStatus('Could not regenerate questions', 'error');
         } finally {
             regenerateButton.disabled = false;
+            resetDefaultsButton.disabled = false;
         }
     };
 
@@ -333,6 +345,20 @@ document.addEventListener('DOMContentLoaded', () => {
         refreshStatus.textContent = '';
         await regenerateQuestions();
         updateUrlQuery();
+    });
+
+    resetDefaultsButton.addEventListener('click', async () => {
+        clearRefreshTimers();
+        refreshStatus.dataset.state = '';
+        refreshStatus.textContent = '';
+        setSelectedCount(defaultCount);
+        selectAllTypes();
+        if (defaultProfileKey) {
+            profileSelect.value = defaultProfileKey;
+            activeProfileKey = defaultProfileKey;
+        }
+        updateUrlQuery();
+        await regenerateQuestions();
     });
 
     quiz.addEventListener('click', (event) => {

--- a/templates/vocab.html
+++ b/templates/vocab.html
@@ -9,10 +9,12 @@
         window.vocabInitialQuestions = {{ questions | tojson }};
         window.vocabAllowedCounts = {{ allowed_counts | tojson }};
         window.vocabSelectedCount = {{ selected_count | tojson }};
+        window.vocabDefaultCount = {{ default_count | tojson }};
         window.vocabPageError = {{ page_error | tojson }};
         window.vocabAllowedTypes = {{ allowed_types | tojson }};
         window.vocabProfiles = {{ profiles | tojson }};
         window.vocabActiveProfileKey = {{ active_profile_key | tojson }};
+        window.vocabDefaultProfileKey = {{ default_profile_key | tojson }};
     </script>
     <script src="{{ url_for('static', filename='js/scripts.js') }}" defer></script>
 </head>
@@ -61,6 +63,7 @@
                     </details>
                 </fieldset>
                 <button type="button" class="vocab-button vocab-button-secondary" id="vocab-regenerate">Regenerate</button>
+                <button type="button" class="vocab-button vocab-button-tertiary" id="vocab-reset-defaults">Reset defaults</button>
                 <span class="vocab-refresh-status" id="vocab-refresh-status" role="status" aria-live="polite"></span>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Allow quizzes with a single question and make the quiz UI able to reset to configured defaults for count, types, and profile.
- Expose server-side default settings to the client so the front-end can initialize and restore the default quiz state.
- Improve UX by adding a reset control and styling for the new button.

### Description
- Added `VOCAB_DEFAULT_COUNT` and extended `VOCAB_ALLOWED_COUNTS` to include `1`, and updated `_get_vocab_count` to use the default constant. 
- Compute `default_profile_key` from the fetched profiles (and pass an empty default on error), and expose `default_count` and `default_profile_key` to the template context. 
- Template changes add `window.vocabDefaultCount` and `window.vocabDefaultProfileKey` and a new `Reset defaults` button in the UI. 
- Front-end changes read the defaults (`defaultCount`, `defaultProfileKey`), add a `setSelectedCount` helper, wire up `vocab-reset-defaults` to restore defaults and re-generate questions, and update allowed counts to include `1`. 
- Added `.vocab-button-tertiary` styles in `styles.css` for the new reset button, and updated `README.md` to document the allowed quiz sizes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a17d28070832685f8ed18a6da05fb)