### PR TITLE
Add Octopus scan-hours dragger (6/8/10/12) and default lookahead=8h

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,10 @@
 from flask import Flask, jsonify, request, abort, send_from_directory, render_template, session
-from tariff_utils import calculate_start_time, get_best_tariff_windows
+from tariff_utils import (
+    ALLOWED_SCAN_HOURS,
+    SCAN_HOURS,
+    calculate_start_time,
+    get_best_tariff_windows,
+)
 import os
 import json
 from datetime import datetime, timedelta
@@ -108,15 +113,28 @@ def tariff():
     return jsonify(startTime=start_time_str)
 
 
+def _resolve_octopus_scan_hours(scan_hours_value):
+    try:
+        scan_hours = int(scan_hours_value)
+    except (TypeError, ValueError):
+        return SCAN_HOURS
+
+    if scan_hours not in ALLOWED_SCAN_HOURS:
+        return SCAN_HOURS
+
+    return scan_hours
+
+
 @app.route('/octopus')
 def octopus():
     # The Octopus page presents fixed appliance durations as a compact table.
     durations = [1, 1.5, 2, 2.5, 3, 3.5]
     page_error = None
     window_rows = []
+    scan_hours = _resolve_octopus_scan_hours(request.args.get('scanHours'))
 
     try:
-        window_rows = get_best_tariff_windows(durations, api_key)
+        window_rows = get_best_tariff_windows(durations, api_key, scan_hours=scan_hours)
     except RuntimeError as error:
         page_error = str(error)
 
@@ -145,6 +163,8 @@ def octopus():
         'octopus.html',
         rows=window_rows,
         page_error=page_error,
+        scan_hours=scan_hours,
+        allowed_scan_hours=ALLOWED_SCAN_HOURS,
     )
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -123,6 +123,50 @@ footer {
     color: #52606d;
 }
 
+.octopus-scan-control {
+    max-width: 540px;
+    margin-top: 1.25rem;
+    padding: 1rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.76);
+    box-shadow: 0 12px 30px rgba(31, 41, 51, 0.06);
+}
+
+.octopus-scan-label {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 0.65rem;
+    font-weight: 700;
+}
+
+.octopus-scan-label output {
+    color: #2f855a;
+    white-space: nowrap;
+}
+
+.octopus-scan-control input[type="range"] {
+    width: 100%;
+    accent-color: #2f855a;
+}
+
+.octopus-scan-control datalist {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 0.15rem;
+    color: #52606d;
+    font-size: 0.85rem;
+}
+
+.octopus-scan-control p {
+    margin: 0.65rem 0 0;
+    color: #52606d;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
 .octopus-banner,
 .octopus-card {
     background: rgba(255, 255, 255, 0.88);

--- a/tariff_utils.py
+++ b/tariff_utils.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 import pytz
 import requests
 
-SCAN_HOURS = 12
+SCAN_HOURS = 8
+ALLOWED_SCAN_HOURS = [6, 8, 10, 12]
 OCTOPUS_TARIFF_URL = (
     "https://api.octopus.energy/v1/products/AGILE-24-10-01/"
     "electricity-tariffs/E-1R-AGILE-24-10-01-C/standard-unit-rates/"
@@ -104,8 +105,8 @@ def find_best_tariff_window(duration_hours, api_key, available_slots=None):
     return best_window
 
 
-def get_best_tariff_windows(duration_hours_list, api_key):
-    available_slots = _fetch_available_slots(api_key)
+def get_best_tariff_windows(duration_hours_list, api_key, scan_hours=SCAN_HOURS):
+    available_slots = _fetch_available_slots(api_key, scan_hours=scan_hours)
     results = []
 
     for duration_hours in duration_hours_list:

--- a/templates/octopus.html
+++ b/templates/octopus.html
@@ -10,11 +10,34 @@
     <main class="octopus-layout">
         <section class="octopus-hero">
             <p class="octopus-kicker">Octopus Agile</p>
-            <h1>Cheapest continuous windows in the next 12 hours</h1>
+            <h1>Cheapest continuous windows in the next {{ scan_hours }} hours</h1>
             <p class="octopus-summary">
                 Each row shows the best upcoming continuous time block for that duration.
                 Negative tariff totals mean you are being credited to use electricity during that window.
             </p>
+            <form class="octopus-scan-control" method="get" action="{{ url_for('octopus') }}">
+                <div class="octopus-scan-label">
+                    <label for="scanHours">Hours in the future to consider</label>
+                    <output id="scanHoursValue" for="scanHours">{{ scan_hours }} hours</output>
+                </div>
+                <input
+                    type="range"
+                    id="scanHours"
+                    name="scanHours"
+                    min="{{ allowed_scan_hours | min }}"
+                    max="{{ allowed_scan_hours | max }}"
+                    step="2"
+                    value="{{ scan_hours }}"
+                    list="scanHourOptions"
+                    aria-describedby="scanHoursHelp"
+                >
+                <datalist id="scanHourOptions">
+                    {% for option in allowed_scan_hours %}
+                    <option value="{{ option }}" label="{{ option }}h"></option>
+                    {% endfor %}
+                </datalist>
+                <p id="scanHoursHelp">Move the dragger to refresh the table for 6, 8, 10, or 12 upcoming hours.</p>
+            </form>
         </section>
 
         {% if page_error %}
@@ -104,5 +127,33 @@
             </div>
         </section>
     </main>
+    <script>
+        const scanHoursInput = document.getElementById('scanHours');
+        const scanHoursValue = document.getElementById('scanHoursValue');
+        const allowedScanHours = {{ allowed_scan_hours | tojson }};
+        let activeScanHours = String(scanHoursInput.value);
+
+        function refreshForScanHours() {
+            if (!allowedScanHours.includes(Number(scanHoursInput.value)) || scanHoursInput.value === activeScanHours) {
+                return;
+            }
+
+            activeScanHours = scanHoursInput.value;
+            scanHoursValue.value = `${activeScanHours} hours`;
+
+            const params = new URLSearchParams(window.location.search);
+            params.set('scanHours', activeScanHours);
+            window.location.href = `${window.location.pathname}?${params.toString()}`;
+        }
+
+        let refreshTimer;
+
+        scanHoursInput.addEventListener('input', () => {
+            scanHoursValue.value = `${scanHoursInput.value} hours`;
+            window.clearTimeout(refreshTimer);
+            refreshTimer = window.setTimeout(refreshForScanHours, 150);
+        });
+        scanHoursInput.addEventListener('change', refreshForScanHours);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Allow users to control how many hours in the future the Octopus page searches for tariff windows using a small, accessible control. 
- Restrict choices to the supported lookahead options `6`, `8`, `10`, and `12` and make `8` the new default instead of `12`. 
- Ensure changing the control immediately refreshes results and that the server receives and validates the selected lookahead before fetching slots.

### Description
- Update `tariff_utils.py` to set `SCAN_HOURS = 8`, add `ALLOWED_SCAN_HOURS = [6, 8, 10, 12]`, and make `get_best_tariff_windows` accept a `scan_hours` argument forwarded to `_fetch_available_slots`. 
- Add `_resolve_octopus_scan_hours` in `app.py` to validate the `scanHours` query parameter and pass the resolved `scan_hours` and `allowed_scan_hours` into the template, and forward `scan_hours` into `get_best_tariff_windows`. 
- Add a range dragger and `datalist` to `templates/octopus.html` that shows the current `scan_hours`, limits selectable values to the allowed set, and uses client-side JS (with a short debounce) to update `scanHours` in the URL and refresh the page when changed. 
- Add styling for the new control in `static/css/styles.css` so the control fits the existing Octopus card design.

### Testing
- Ran `python3 -m compileall app.py tariff_utils.py` which completed successfully. 
- Rendered the Jinja template via a small script to verify the dynamic heading, control `value=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a248b38b3ac8326b4ff76a5b0ff35ea)