### PR TITLE
Add vocabulary word bank entries

### DIFF
--- a/static/English/Vocabulary/word_bank.txt
+++ b/static/English/Vocabulary/word_bank.txt
@@ -395,3 +395,12 @@ Poultry
 Pageant
 Garret
 Sallied
+Occupy
+occur
+profession
+relevant
+secretary
+signature
+suggest
+thorough
+variety


### PR DESCRIPTION
### Motivation
- Add nine requested words to the project's vocabulary word bank so they are available for question generation and sampling.

### Description
- Appended `Occupy`, `occur`, `profession`, `relevant`, `secretary`, `signature`, `suggest`, `thorough`, and `variety` to `static/English/Vocabulary/word_bank.txt`, preserving one item per line and the file newline, and ensured no case-insensitive duplicates were introduced.

### Testing
- Ran a short Python duplicate-check (`python3 - <<'PY' ... PY`) which reported `duplicates=0` and `non_empty_entries=406`, inspected the `git diff` showing the nine appended lines, and committed the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47f8352cf48326940fd87d3abb3915)