### PR TITLE
Rebalance vocabulary word bank

### DIFF
--- a/static/English/Vocabulary/word_bank.txt.backup.05
+++ b/static/English/Vocabulary/word_bank.txt.backup.05
@@ -2,12 +2,14 @@ Gorge
 scramble
 moor
 visor
+tidings
 dozed
 wigwam
 trickled
 forded
 earnest
 alighted
+overcast
 sustaining
 looming
 fusty
@@ -41,6 +43,7 @@ wrenched
 prow
 harbour
 avenue
+enmity
 reckoned
 whizzing
 coracle
@@ -54,6 +57,7 @@ avenge
 allegiance
 bewitched
 battened
+cataract
 becalmed
 patronizing
 fathoms
@@ -102,6 +106,7 @@ rigmarole
 disbursed
 overawed
 fief
+slovenly
 postern
 gauntlet
 languid
@@ -111,6 +116,8 @@ forfeit
 ingratiating
 perpetually
 liege
+woebegone
+innumerable
 confounded
 unseemly
 bestowed
@@ -238,6 +245,8 @@ indignant
 reeking
 dictator
 perspicacious
+pristine
+amiable
 nonchalant
 bad
 grievous
@@ -259,6 +268,7 @@ hypothesis
 analyze
 summarize
 billeting
+imminent
 Bewildered
 Adamant
 Stockily
@@ -290,6 +300,7 @@ prattled
 scullery
 haunch
 delicacy
+fidgety
 cumbered
 clamour
 crevice


### PR DESCRIPTION
### Motivation

- Reduce over-representation of words that already appear frequently as `target_word` so future question generation focuses on underused vocabulary. 
- Preserve a recoverable snapshot of the original word bank before making destructive edits. 
- Keep the on-disk word bank consistent with the repository's question-generation heuristics described in the local `AGENTS.md`.

### Description

- Performed a words census against `static/English/Vocabulary/questions.json` and `static/English/Vocabulary/word_bank.txt` to compute usage counts and a histogram of occurrences. 
- Created a backup `static/English/Vocabulary/word_bank.txt.backup.05` containing the original 440 non-empty entries and then updated `static/English/Vocabulary/word_bank.txt` to retain only words used 0 or 1 times. 
- Removed 11 entries that appeared 2+ times as `target_word`: tidings, overcast, enmity, cataract, slovenly, woebegone, innumerable, pristine, amiable, imminent, fidgety, resulting in 429 retained entries and a post-rebalance histogram of `{0: 359, 1: 70}`.

### Testing

- Validated `questions.json` syntax with `python3 -m json.tool static/English/Vocabulary/questions.json`, which succeeded. 
- Ran the census and rebalancing script that produced pre/post counts and the removed word list and completed without error. 
- Verified there are no case-insensitive duplicates in the updated `static/English/Vocabulary/word_bank.txt` with a custom `casefold()` check, which returned zero duplicates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5169d6029483268dc830dd0b993151)